### PR TITLE
[feat/front] add-searchPage

### DIFF
--- a/frontend/app/src/main/AndroidManifest.xml
+++ b/frontend/app/src/main/AndroidManifest.xml
@@ -19,6 +19,9 @@
             android:name=".TempActivity"
             android:exported="false" />
         <activity
+            android:name=".SearchActivity"
+            android:exported="false" />
+        <activity
             android:name=".ResultActivity"
             android:exported="false" />
         <activity

--- a/frontend/app/src/main/java/com/example/frontend/MainActivity.kt
+++ b/frontend/app/src/main/java/com/example/frontend/MainActivity.kt
@@ -71,12 +71,28 @@ class MainActivity : AppCompatActivity() {
 
         loadInfo(cookie, this)
 
-        //테스트용으로 resultPage로 가게끔
-        binding.imageView.setOnClickListener(){
-            val intent = Intent(this, ResultActivity::class.java)
+        //검색버튼
+        binding.search.setOnClickListener(){
+            /*
+            val searchText = binding.searchText.text.toString()
+            if(searchText.isEmpty() || searchText.isBlank()){
+                Toast.makeText(this, "입력이 없습니다", Toast.LENGTH_SHORT).show()
+            }
+            //goto Select Activity with String Arr
+            else{
+                val search = ArrayList<String>()
+                search.add(searchText)
+
+                val intent = Intent(this, SearchActivity::class.java)
+                intent.putStringArrayListExtra("search", search)
+                startActivity(intent)
+            }
+            */
+            val intent = Intent(this, SearchActivity::class.java)
             startActivity(intent)
-            finish()
         }
+
+        //편집버튼
         binding.EditButton.setOnClickListener(){
             val intent = Intent(this, EditActivity::class.java)
             intent.putExtra("allergyList", allergyList)
@@ -97,6 +113,7 @@ class MainActivity : AppCompatActivity() {
             cameraLauncher.launch(tempImageUri)
         }
 
+        //로그아웃
         binding.logout.setOnClickListener(){
             val intent = Intent(this, LoginActivity::class.java)
             MySharedPreferences.clearUser(this)

--- a/frontend/app/src/main/java/com/example/frontend/ResultActivity.kt
+++ b/frontend/app/src/main/java/com/example/frontend/ResultActivity.kt
@@ -44,22 +44,25 @@ class ResultActivity : AppCompatActivity() {
 
         val cookie = MySharedPreferences.getMyCookie(this)
 
-        //val targets = intent.getStringArrayListExtra("confirm") //searchPage에서 넘어올 때
-        val targets = arrayListOf<String>("게보린에프정", "낙센정", "타라신주", "메부톤정", "아스로펜정", "세로클캡슐", "룩펠정", "솔레톤정") //약물 이름으로 입력
+        val targets = intent.getStringArrayListExtra("confirm") //searchPage에서 넘어올 때
 
-        //request & load to UI by Thread
-        window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
-        getResult(cookie, targets)
+        if(targets != null){
+            //request & load to UI by Thread
+            window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
+            getResult(cookie, targets)
 
-        //Just load Medicine Name with dynamic View generation
-        loadMedicine(targets)
+            //Just load Medicine Name with dynamic View generation
+            loadMedicine(targets)
 
-        //loading Dialog 설정 및 표시
-        loadingDialog = ProgressDialog(this, android.R.style.Theme_Material_Dialog_Alert)
-        loadingDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER)
-        loadingDialog.setMessage("결과 받아오는 중...")
-        loadingDialog.setCanceledOnTouchOutside(false)
-        loadingDialog.show()
+            //loading Dialog 설정 및 표시
+            loadingDialog = ProgressDialog(this, android.R.style.Theme_Material_Dialog_Alert)
+            loadingDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER)
+            loadingDialog.setMessage("결과 받아오는 중...")
+            loadingDialog.setCanceledOnTouchOutside(false)
+            loadingDialog.show()
+        }else{
+            Toast.makeText(this, "결과가 없습니다.", Toast.LENGTH_SHORT).show()
+        }
 
         //완료버튼 클릭 to Main
         binding.toMain.setOnClickListener {

--- a/frontend/app/src/main/java/com/example/frontend/SearchActivity.kt
+++ b/frontend/app/src/main/java/com/example/frontend/SearchActivity.kt
@@ -1,0 +1,233 @@
+package com.example.frontend
+
+import android.R
+import android.annotation.SuppressLint
+import android.app.ProgressDialog
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.Paint
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.text.Layout
+import android.text.Layout.Alignment
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.widget.*
+import com.example.frontend.databinding.ActivitySearchBinding
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.IOException
+
+class SearchActivity : AppCompatActivity() {
+
+    lateinit var binding: ActivitySearchBinding
+    private lateinit var loadingDialog: ProgressDialog
+    private val spinnerDefault = "약물을 선택하세요"
+    private val none = "검색되는 약물이 없습니다"
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivitySearchBinding.inflate(layoutInflater)
+        var view = binding.root
+        setContentView(view)
+
+        val cookie = MySharedPreferences.getMyCookie(this)
+
+        //val searchTargets = intent.getStringArrayListExtra("search") //Main 검색 or OCR 스캔 검색
+        val searchTargets = arrayListOf<String>("낙센", "아스피린", "게보린", "타이레놀")
+
+        if(searchTargets != null){
+            //request & load to UI by Thread
+            window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
+            getResult(cookie, searchTargets)
+
+            //Just load Medicine Name with dynamic View generation
+            loadMedicine(searchTargets)
+
+            //loading Dialog 설정 및 표시
+            loadingDialog = ProgressDialog(this, R.style.Theme_Material_Dialog_Alert)
+            loadingDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER)
+            loadingDialog.setMessage("리스트 설정하는 중...")
+            loadingDialog.setCanceledOnTouchOutside(false)
+            loadingDialog.show()
+        }else{
+            Toast.makeText(this, "결과가 없습니다.", Toast.LENGTH_SHORT).show()
+        }
+
+        //완료버튼 클릭 to Main
+        binding.toResult.setOnClickListener {
+
+            val confirm = confirmSelected()
+
+            if(confirm.contains(spinnerDefault)){
+                Toast.makeText(this, "선택을 완료해주세요", Toast.LENGTH_SHORT).show()
+            }
+            else if(confirm.size == 0){
+                Toast.makeText(this, "검색할 수 있는 약물이 없습니다", Toast.LENGTH_SHORT).show()
+            }
+            else{
+                val intent = Intent(this, ResultActivity::class.java)
+                intent.putStringArrayListExtra("confirm", confirm)
+                startActivity(intent)
+                finish()
+            }
+        }
+    }
+
+    private fun confirmSelected(): ArrayList<String>{
+        val tableLayout = binding.table
+        var row: TableRow
+        var spinner: Spinner
+
+        val trim = ArrayList<String>()
+
+        for(i in 0 until tableLayout.childCount) {
+            row = tableLayout.getChildAt(i) as TableRow
+            spinner = row.getChildAt(1) as Spinner
+
+            val selected = spinner.selectedItem.toString()
+            if(selected != none)
+                trim.add(selected)
+        }
+
+        return trim
+    }
+
+    private fun getResult(ck: String?, args: ArrayList<String>){
+        val urlBuilder: HttpUrl.Builder = "http://34.125.3.13:8000/search".toHttpUrl().newBuilder()
+        args.forEach {
+            urlBuilder.addQueryParameter("mname", it)
+        }
+        val url = urlBuilder.build()
+
+        if (ck != null) {
+            val request: Request = Request.Builder()
+                .url(url)
+                .addHeader("Cookie", ck)
+                .build()
+            val client = OkHttpClient()
+
+            client.newCall(request).enqueue(object : okhttp3.Callback {
+                override fun onFailure(call: okhttp3.Call, e: IOException) {
+                    Log.d("connection", "fail")
+                }
+
+                override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                    Log.d("connection", "success")
+
+                    if (response.isSuccessful) {
+                        val response = response.body?.string()
+                        val responseArr = JSONArray(response)
+
+                        var eachResultArr = ArrayList<ArrayList<String>>()
+
+                        var tempJsonArr: JSONArray
+                        var tempJsonObj: JSONObject
+                        for(i in 0 until responseArr.length()) {
+                            var tempStrArr = ArrayList<String>()
+                            tempJsonArr = responseArr.getJSONArray(i)
+                            for(j in 0 until tempJsonArr.length()){
+                                tempJsonObj = tempJsonArr.getJSONObject(j)
+                                tempStrArr.add(tempJsonObj.getString("mname"))
+                            }
+                            eachResultArr.add(tempStrArr)
+                        }
+
+                        println(eachResultArr)
+
+                        //update UI with result
+                        loadResult(eachResultArr)
+
+                    } else { //not success!
+                        Log.d("connection", "Bad")
+                    }
+                }
+            })
+        }
+    }
+
+    @SuppressLint("DiscouragedPrivateApi")
+    private fun loadMedicine(args: ArrayList<String>){
+        val tableLayout = findViewById<TableLayout>(com.example.frontend.R.id.table)
+
+        val rowLayoutParams = TableLayout.LayoutParams(
+            TableLayout.LayoutParams.MATCH_PARENT,
+            TableLayout.LayoutParams.WRAP_CONTENT
+        )
+        rowLayoutParams.setMargins(0, 2, 0, 2)
+        val textViewLayoutParams = TableRow.LayoutParams(
+            TableRow.LayoutParams.WRAP_CONTENT,
+            TableRow.LayoutParams.MATCH_PARENT
+        )
+
+        val len = args.size
+        for(i in 0 until len){
+            val row = TableRow(this)
+            val label = TextView(this)
+            val content = Spinner(this)
+
+            //set row
+            row.setBackgroundColor(Color.WHITE)
+
+            //set label
+            val str = args[i]
+            label.text = str
+            label.textSize = 16F
+            label.textAlignment = View.TEXT_ALIGNMENT_CENTER
+            label.gravity = Gravity.CENTER_VERTICAL
+
+            //set spinner
+            val popUp = Spinner::class.java.getDeclaredField("mPopup")
+            popUp.isAccessible = true
+
+            val window = popUp.get(content) as ListPopupWindow
+            window.height = 700
+
+            //add
+            row.addView(label, textViewLayoutParams)
+            row.addView(content)
+
+            tableLayout.addView(row, rowLayoutParams)
+        }
+    }
+
+    fun loadResult(result: ArrayList<ArrayList<String>>){
+        Thread(){
+            run(){
+                runOnUiThread(Runnable {
+                    run(){
+                        val tableLayout = findViewById<TableLayout>(com.example.frontend.R.id.table)
+                        var row: TableRow
+                        var content: Spinner
+
+                        for(i in 0 until tableLayout.childCount) {
+                            row = tableLayout.getChildAt(i) as TableRow
+                            content = row.getChildAt(1) as Spinner
+
+                            if(result[i].size == 0){
+                                result[i].add(0, none)
+                            }
+                            else{
+                                result[i].add(0, spinnerDefault)
+                            }
+                            content.adapter = ArrayAdapter<String>(
+                                this,
+                                android.R.layout.simple_spinner_dropdown_item,
+                                result[i]
+                            )
+                            content.setSelection(0) //defalut
+                        }
+                        loadingDialog.dismiss()
+                        window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
+                    }
+                })
+            }
+        }.start()
+    }
+}

--- a/frontend/app/src/main/res/layout/activity_main.xml
+++ b/frontend/app/src/main/res/layout/activity_main.xml
@@ -32,7 +32,7 @@
         app:layout_constraintBottom_toTopOf="@+id/tableLayout"
         app:layout_constraintEnd_toStartOf="@+id/EditButton"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/editTextTextPersonName2"
+        app:layout_constraintTop_toBottomOf="@+id/searchText"
         tools:ignore="MissingConstraints,TouchTargetSizeCheck" />
 
 
@@ -109,7 +109,7 @@
         app:layout_constraintVertical_bias="0.0"></androidx.recyclerview.widget.RecyclerView>
 
     <EditText
-        android:id="@+id/editTextTextPersonName2"
+        android:id="@+id/searchText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
@@ -127,11 +127,11 @@
         tools:ignore="MissingConstraints,TouchTargetSizeCheck" />
 
     <ImageView
-        android:id="@+id/imageView5"
+        android:id="@+id/search"
         android:layout_width="40dp"
         android:layout_height="49dp"
         android:layout_marginTop="115dp"
-        app:layout_constraintStart_toEndOf="@+id/editTextTextPersonName2"
+        app:layout_constraintStart_toEndOf="@+id/searchText"
         app:layout_constraintTop_toTopOf="@id/imageView"
         app:srcCompat="@drawable/resource" />
 

--- a/frontend/app/src/main/res/layout/activity_search.xml
+++ b/frontend/app/src/main/res/layout/activity_search.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SearchActivity">
+
+    <ImageView
+        android:id="@+id/imageView4"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:layout_marginTop="80dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/logo" />
+
+    <ScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="32dp"
+        app:layout_constraintBottom_toTopOf="@+id/toResult"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView3"
+        app:layout_constraintVertical_bias="0.0">
+
+        <TableLayout
+            android:id="@+id/table"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/actionColor"
+            android:stretchColumns="0, 1">
+        </TableLayout>
+
+    </ScrollView>
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="300dp"
+        android:layout_height="30dp"
+        android:layout_marginTop="32dp"
+        android:background="@drawable/rounding"
+        android:fontFamily="sans-serif"
+        android:gravity="center"
+        android:text="약물 검색 결과"
+        android:textAlignment="center"
+        android:textColor="@color/white"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/imageView4" />
+
+    <Button
+        android:id="@+id/toResult"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="35dp"
+        android:backgroundTint="@color/actionColor"
+        android:text="결과 확인"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- 검색 약물의 리스트에 대한 ElasticSearch 수행 후 이에 대한 결과값을 개별 스피너로 출력
- 결과값이 없는 경우 "검색된 약물이 없습니다"를 출력하며 resultPage로 이동할 때 제외
- 에뮬레이터의 한글 키보드 지원이 안 되는 관계로 main에서 검색 클릭 시 해당 약물 전달 대신 임의로 지정한 약물 리스트에 대하여 작업 수행 (주석으로 변경가능)
-  resultPage와의 연결은 잘 되는 것으로 확인
- 추가적으로 main -> search, ocr -> search로 넘겨주는 작업을 고려해야함